### PR TITLE
Simplify the Pointer API

### DIFF
--- a/src/windows/module/module_enum.rs
+++ b/src/windows/module/module_enum.rs
@@ -10,7 +10,6 @@ use winapi::shared::minwindef::{DWORD, FALSE, HMODULE};
 use crate::process::ProcessId;
 use crate::error::ErrorCode;
 use crate::util::from_wchar_buf;
-use crate::ptr::{RawPtr, NativePtr};
 use crate::{Result, IntoInner, FromInner};
 
 /// Module enumeration.
@@ -68,8 +67,8 @@ impl ModuleEntry {
 		unsafe { ProcessId::from_inner(self.0.th32ProcessID) }
 	}
 	/// The base address of the module in the context of the owning process.
-	pub fn base(&self) -> RawPtr {
-		RawPtr::from_usize(self.0.modBaseAddr as usize)
+	pub fn base(&self) -> usize {
+		self.0.modBaseAddr as usize
 	}
 	/// The size of the module, in bytes.
 	pub fn size(&self) -> usize {
@@ -104,8 +103,8 @@ impl fmt::Debug for ModuleEntry {
 			.field("th32ProcessID", &self.0.th32ProcessID)
 			//.field("GlblcntUsage", &self.0.GlblcntUsage)
 			//.field("ProccntUsage", &self.0.ProccntUsage)
-			.field("modBaseAddr", &self.0.modBaseAddr)
-			.field("modBaseSize", &(self.0.modBaseSize as *const ()))
+			.field("modBaseAddr", &format_args!("{:#x}", self.base()))
+			.field("modBaseSize", &format_args!("{:#x}", self.size()))
 			.field("hModule", &self.0.hModule)
 			.field("szModule", &self.name())
 			.field("szExePath", &self.exe_path())

--- a/src/windows/module/module_iter.rs
+++ b/src/windows/module/module_iter.rs
@@ -2,8 +2,6 @@ use std::{fmt, mem};
 
 use winapi::shared::ntdef::{LIST_ENTRY, PVOID, ULONG, UNICODE_STRING, SHORT, UCHAR};
 
-use crate::ptr::{RawPtr, NativePtr};
-
 #[allow(non_snake_case)]
 #[repr(C)]
 struct LDR_DATA_ENTRY {
@@ -130,18 +128,18 @@ pub struct ModuleDataEntry {
 	data_entry: *mut LDR_DATA_ENTRY,
 }
 impl ModuleDataEntry {
-	pub fn base_address(&self) -> RawPtr {
-		unsafe { RawPtr::from_usize((*self.data_entry).BaseAddress as usize) }
+	pub fn base_address(&self) -> usize {
+		unsafe { (*self.data_entry).BaseAddress as usize }
 	}
-	pub fn entry_point(&self) -> RawPtr {
-		unsafe { RawPtr::from_usize((*self.data_entry).EntryPoint as usize) }
+	pub fn entry_point(&self) -> usize {
+		unsafe { (*self.data_entry).EntryPoint as usize }
 	}
 }
 impl fmt::Debug for ModuleDataEntry {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.debug_struct("ModuleDataEntry")
-			.field("base_address", &self.base_address())
-			.field("entry_point", &self.entry_point())
+			.field("base_address", &format_args!("{:#x}", self.base_address()))
+			.field("entry_point", &format_args!("{:#x}", self.entry_point()))
 			.finish()
 	}
 }

--- a/src/windows/process/process.rs
+++ b/src/windows/process/process.rs
@@ -12,7 +12,6 @@ use winapi::shared::minwindef::{LPVOID, DWORD, TRUE, FALSE};
 
 use crate::process::{ProcessId, ProcessRights};
 use crate::thread::Thread;
-use crate::ptr::{RawPtr, NativePtr};
 use crate::error::ErrorCode;
 use crate::{Result, IntoInner, FromInner};
 
@@ -72,10 +71,8 @@ impl Process {
 			}
 		}
 	}
-	pub fn create_thread(&self, start_address: RawPtr, parameter: RawPtr) -> Result<Thread> {
+	pub fn create_thread(&self, start_address: usize, parameter: usize) -> Result<Thread> {
 		unsafe {
-			let start_address = start_address.into_usize();
-			let parameter = parameter.into_usize();
 			let handle = CreateRemoteThread(self.0, ptr::null_mut(), 0, mem::transmute(start_address), parameter as LPVOID, 0, ptr::null_mut());
 			if handle.is_null() {
 				Err(ErrorCode::last())

--- a/src/windows/process/process_list.rs
+++ b/src/windows/process/process_list.rs
@@ -7,7 +7,6 @@ use ntdll::*;
 use crate::FromInner;
 use crate::thread::ThreadId;
 use crate::process::ProcessId;
-use crate::ptr::{RawPtr, NativePtr};
 
 //----------------------------------------------------------------
 
@@ -111,8 +110,8 @@ impl fmt::Debug for ProcessInformation {
 #[repr(C)]
 pub struct ThreadInformation(SYSTEM_THREAD_INFORMATION);
 impl ThreadInformation {
-	pub fn start_address(&self) -> RawPtr {
-		RawPtr::from_usize(self.0.StartAddress as usize)
+	pub fn start_address(&self) -> usize {
+		self.0.StartAddress as usize
 	}
 	pub fn process_id(&self) -> ProcessId {
 		unsafe {

--- a/src/windows/ptr/mod.rs
+++ b/src/windows/ptr/mod.rs
@@ -35,73 +35,20 @@ All the pointer types implement these interfaces:
 mod ptr64;
 mod ptr32;
 
-pub use self::ptr64::{RawPtr64, TypePtr64};
-pub use self::ptr32::{RawPtr32, TypePtr32};
+pub use self::ptr64::Ptr64;
+pub use self::ptr32::Ptr32;
 
 #[cfg(target_pointer_width = "64")]
-pub type RawPtr = RawPtr64;
-#[cfg(target_pointer_width = "64")]
-pub type TypePtr<T> = TypePtr64<T>;
+pub type Ptr<T> = Ptr64<T>;
 
 #[cfg(target_pointer_width = "32")]
-pub type RawPtr = RawPtr32;
-#[cfg(target_pointer_width = "32")]
-pub type TypePtr<T> = TypePtr32<T>;
+pub type Ptr<T> = Ptr32<T>;
 
 mod pod;
 pub use self::pod::Pod;
 
-/// Interact with pointers on the native target.
-pub trait NativePtr: Sized {
-	/// Converts the pointer to a `usize` value.
-	fn into_usize(self) -> usize;
-	/// Creates a pointer from a `usize` value.
-	fn from_usize(address: usize) -> Self;
-}
-
-#[cfg(target_pointer_width = "64")]
-impl NativePtr for RawPtr64 {
-	fn into_usize(self) -> usize {
-		self.into_u64() as usize
-	}
-	fn from_usize(address: usize) -> RawPtr64 {
-		RawPtr64::from(address as u64)
-	}
-}
-#[cfg(target_pointer_width = "64")]
-impl<T: ?Sized> NativePtr for TypePtr64<T> {
-	fn into_usize(self) -> usize {
-		self.into_u64() as usize
-	}
-	fn from_usize(address: usize) -> TypePtr64<T> {
-		TypePtr64::from(address as u64)
-	}
-}
-
-impl NativePtr for RawPtr32 {
-	fn into_usize(self) -> usize {
-		self.into_u32() as usize
-	}
-	fn from_usize(address: usize) -> RawPtr32 {
-		RawPtr32::from(address as u32)
-	}
-}
-impl<T: ?Sized> NativePtr for TypePtr32<T> {
-	fn into_usize(self) -> usize {
-		self.into_u32() as usize
-	}
-	fn from_usize(address: usize) -> TypePtr32<T> {
-		TypePtr32::from(address as u32)
-	}
-}
-
-impl From<RawPtr32> for RawPtr64 {
-	fn from(ptr: RawPtr32) -> RawPtr64 {
-		RawPtr64::from(ptr.into_u32() as u64)
-	}
-}
-impl<T: ?Sized> From<TypePtr32<T>> for TypePtr64<T> {
-	fn from(ptr: TypePtr32<T>) -> TypePtr64<T> {
-		TypePtr64::from(ptr.into_u32() as u64)
+impl<T: ?Sized> From<Ptr32<T>> for Ptr64<T> {
+	fn from(ptr: Ptr32<T>) -> Ptr64<T> {
+		Ptr64::from(ptr.into_raw() as u64)
 	}
 }

--- a/src/windows/ptr/pod.rs
+++ b/src/windows/ptr/pod.rs
@@ -13,6 +13,8 @@ pub unsafe trait Pod {
 	}
 }
 
+// unsafe impl Pod for .. {}
+
 unsafe impl Pod for u8 {}
 unsafe impl Pod for u16 {}
 unsafe impl Pod for u32 {}
@@ -28,4 +30,15 @@ unsafe impl Pod for f64 {}
 
 unsafe impl<T: Pod> Pod for [T] {}
 
-//unsafe impl Pod for .. {}
+macro_rules! impl_pod_array {
+	($n:tt $($tail:tt)+) => {
+		unsafe impl<T: Pod> Pod for [T; $n] {}
+		impl_pod_array!($($tail)+);
+	};
+	($n:tt) => {
+		unsafe impl<T: Pod> Pod for [T; $n] {}
+	};
+}
+impl_pod_array!(0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15);
+impl_pod_array!(16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31);
+impl_pod_array!(32 48 64 80 100 128 160 192 256 512 768 1024 2048 4096);

--- a/src/windows/ptr/ptr32.rs
+++ b/src/windows/ptr/ptr32.rs
@@ -4,183 +4,100 @@ use std::marker::PhantomData;
 
 use super::Pod;
 
-//----------------------------------------------------------------
-
-/// 32bit Raw Pointer.
-#[derive(Copy, Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[repr(C)]
-pub struct RawPtr32(u32);
-
-impl From<u32> for RawPtr32 {
-	fn from(address: u32) -> RawPtr32 {
-		RawPtr32(address)
-	}
-}
-impl From<RawPtr32> for u32 {
-	fn from(ptr: RawPtr32) -> u32 {
-		ptr.0
-	}
-}
-
-impl<T: ?Sized> From<TypePtr32<T>> for RawPtr32 {
-	fn from(ptr: TypePtr32<T>) -> RawPtr32 {
-		RawPtr32(ptr.0)
-	}
-}
-
-impl RawPtr32 {
-	/// Returns a raw null pointer.
-	pub fn null() -> RawPtr32 {
-		RawPtr32(0)
-	}
-	/// Returns if the pointer is the null pointer.
-	pub fn is_null(self) -> bool {
-		self.0 == 0
-	}
-	/// Converts to a `u32` value.
-	pub fn into_u32(self) -> u32 {
-		self.0
-	}
-	/// Converts to a typed pointer.
-	pub fn into_typed<T: ?Sized>(self) -> TypePtr32<T> {
-		TypePtr32(self.0, PhantomData)
-	}
-}
-impl ops::Sub for RawPtr32 {
-	type Output = i32;
-	fn sub(self, rhs: RawPtr32) -> i32 {
-		u32::wrapping_sub(self.0, rhs.0) as i32
-	}
-}
-impl fmt::Display for RawPtr32 {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "{:>#010X}", self.0)
-	}
-}
-impl fmt::Debug for RawPtr32 {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "RawPtr32({:>#010X})", self.0)
-	}
-}
-impl ops::Add<u32> for RawPtr32 {
-	type Output = RawPtr32;
-	fn add(self, rhs: u32) -> RawPtr32 {
-		RawPtr32(self.0 + rhs)
-	}
-}
-impl ops::Sub<u32> for RawPtr32 {
-	type Output = RawPtr32;
-	fn sub(self, rhs: u32) -> RawPtr32 {
-		RawPtr32(self.0 - rhs)
-	}
-}
-
-//----------------------------------------------------------------
-
 /// 32bit Typed Pointer.
 #[repr(C)]
-pub struct TypePtr32<T: ?Sized>(u32, PhantomData<fn() -> T>);
+pub struct Ptr32<T: ?Sized>(u32, PhantomData<fn() -> T>);
 
-impl<T: ?Sized> From<u32> for TypePtr32<T> {
-	fn from(address: u32) -> TypePtr32<T> {
-		TypePtr32(address, PhantomData)
+impl<T: ?Sized> From<u32> for Ptr32<T> {
+	fn from(address: u32) -> Ptr32<T> {
+		Ptr32(address, PhantomData)
 	}
 }
-impl<T: ?Sized> From<TypePtr32<T>> for u32 {
-	fn from(ptr: TypePtr32<T>) -> u32 {
+impl<T: ?Sized> From<Ptr32<T>> for u32 {
+	fn from(ptr: Ptr32<T>) -> u32 {
 		ptr.0
 	}
 }
-impl<T: ?Sized> From<RawPtr32> for TypePtr32<T> {
-	fn from(ptr: RawPtr32) -> TypePtr32<T> {
-		TypePtr32(ptr.0, PhantomData)
-	}
-}
 
-impl<T: ?Sized> TypePtr32<T> {
+impl<T: ?Sized> Ptr32<T> {
 	/// Returns a raw null pointer.
-	pub fn null() -> TypePtr32<T> {
-		TypePtr32(0, PhantomData)
+	pub fn null() -> Ptr32<T> {
+		Ptr32(0, PhantomData)
 	}
 	/// Returns if the pointer is the null pointer.
 	pub fn is_null(self) -> bool {
 		self.0 == 0
 	}
-	/// Converts to a `u32` value.
-	pub fn into_u32(self) -> u32 {
+	/// Converts to a raw integer value.
+	pub fn into_raw(self) -> u32 {
 		self.0
 	}
-	/// Converts to a raw pointer.
-	pub fn into_raw(self) -> RawPtr32 {
-		RawPtr32(self.0)
+}
+impl<T> Ptr32<[T]> {
+	pub fn decay(self) -> Ptr32<T> {
+		Ptr32(self.0, PhantomData)
+	}
+	pub fn at(self, index: usize) -> Ptr32<T> {
+		Ptr32(self.0 + mem::size_of::<T>() as u32 * index as u32, PhantomData)
 	}
 }
-impl<T> TypePtr32<[T]> {
-	pub fn decay(self) -> TypePtr32<T> {
-		TypePtr32(self.0, PhantomData)
-	}
-	pub fn at(self, index: usize) -> TypePtr32<T> {
-		TypePtr32(self.0 + mem::size_of::<T>() as u32 * index as u32, PhantomData)
-	}
-}
-impl<T> ops::Sub for TypePtr32<T> {
+impl<T> ops::Sub for Ptr32<T> {
 	type Output = i32;
-	fn sub(self, rhs: TypePtr32<T>) -> i32 {
+	fn sub(self, rhs: Ptr32<T>) -> i32 {
 		(u32::wrapping_sub(self.0, rhs.0) as i32) / mem::size_of::<T>() as i32
 	}
 }
-impl<T: ?Sized> fmt::Display for TypePtr32<T> {
+impl<T: ?Sized> fmt::Display for Ptr32<T> {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "{:>#010X}", self.0)
 	}
 }
-impl<T: ?Sized> fmt::Debug for TypePtr32<T> {
+impl<T: ?Sized> fmt::Debug for Ptr32<T> {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "TypePtr32({:>#010X})", self.0)
+		write!(f, "Ptr32({:>#010X})", self.0)
 	}
 }
-impl<T> ops::Add<u32> for TypePtr32<T> {
-	type Output = TypePtr32<T>;
-	fn add(self, rhs: u32) -> TypePtr32<T> {
-		TypePtr32(self.0 + rhs * mem::size_of::<T>() as u32, self.1)
+impl<T> ops::Add<u32> for Ptr32<T> {
+	type Output = Ptr32<T>;
+	fn add(self, rhs: u32) -> Ptr32<T> {
+		Ptr32(self.0 + rhs * mem::size_of::<T>() as u32, self.1)
 	}
 }
-impl<T> ops::Sub<u32> for TypePtr32<T> {
-	type Output = TypePtr32<T>;
-	fn sub(self, rhs: u32) -> TypePtr32<T> {
-		TypePtr32(self.0 - rhs * mem::size_of::<T>() as u32, self.1)
+impl<T> ops::Sub<u32> for Ptr32<T> {
+	type Output = Ptr32<T>;
+	fn sub(self, rhs: u32) -> Ptr32<T> {
+		Ptr32(self.0 - rhs * mem::size_of::<T>() as u32, self.1)
 	}
 }
-impl<T: ?Sized> Clone for TypePtr32<T> {
+impl<T: ?Sized> Clone for Ptr32<T> {
 	fn clone(&self) -> Self {
-		TypePtr32(self.0, self.1)
+		Ptr32(self.0, self.1)
 	}
 }
-impl<T: ?Sized> Default for TypePtr32<T> {
-	fn default() -> TypePtr32<T> {
-		TypePtr32::null()
+impl<T: ?Sized> Default for Ptr32<T> {
+	fn default() -> Ptr32<T> {
+		Ptr32::null()
 	}
 }
-impl<T: ?Sized> PartialEq for TypePtr32<T> {
+impl<T: ?Sized> PartialEq for Ptr32<T> {
 	fn eq(&self, rhs: &Self) -> bool {
 		self.0 == rhs.0
 	}
 }
-impl<T: ?Sized> PartialOrd for TypePtr32<T> {
-	fn partial_cmp(&self, rhs: &TypePtr32<T>) -> Option<cmp::Ordering> {
+impl<T: ?Sized> PartialOrd for Ptr32<T> {
+	fn partial_cmp(&self, rhs: &Ptr32<T>) -> Option<cmp::Ordering> {
 		self.0.partial_cmp(&rhs.0)
 	}
 }
-impl<T: ?Sized> Copy for TypePtr32<T> {}
-impl<T: ?Sized> Eq for TypePtr32<T> {}
-impl<T: ?Sized> Ord for TypePtr32<T> {
-	fn cmp(&self, rhs: &TypePtr32<T>) -> cmp::Ordering {
+impl<T: ?Sized> Copy for Ptr32<T> {}
+impl<T: ?Sized> Eq for Ptr32<T> {}
+impl<T: ?Sized> Ord for Ptr32<T> {
+	fn cmp(&self, rhs: &Ptr32<T>) -> cmp::Ordering {
 		self.0.cmp(&rhs.0)
 	}
 }
 
-unsafe impl Pod for RawPtr32 {}
-unsafe impl<T: ?Sized> Pod for TypePtr32<T> {}
+unsafe impl<T: ?Sized> Pod for Ptr32<T> {}
 
 //----------------------------------------------------------------
 
@@ -190,26 +107,14 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn rawptr32() {
-		let a = RawPtr32::from(0x1000);
-		let b = a + 0x20;
-		let c = a - 0x20;
-		assert_eq!(mem::size_of_val(&a), 4);
-		assert_eq!(b - a, 0x20);
-		assert_eq!(c.into_u32(), 0x0FE0);
-		assert_eq!(format!("{}", a), "0x00001000");
-		assert_eq!(b.into_typed::<i32>(), TypePtr32::<i32>::from(0x1020));
-	}
-
-	#[test]
 	fn typeptr32() {
-		let a = TypePtr32::<f32>::from(0x2000);
+		let a = Ptr32::<f32>::from(0x2000);
 		let b = a + 0x40;
 		let c = a - 0x40;
 		assert_eq!(mem::size_of_val(&a), 4);
 		assert_eq!(c - a, -0x40);
-		assert_eq!(b.into_u32(), 0x2100);
+		assert_eq!(b.into_raw(), 0x2100);
 		assert_eq!(format!("{}", a), "0x00002000");
-		assert_eq!(c.into_raw(), RawPtr32::from(0x1F00));
+		assert_eq!(c.into_raw(), 0x1F00);
 	}
 }

--- a/src/windows/ptr/ptr64.rs
+++ b/src/windows/ptr/ptr64.rs
@@ -4,183 +4,100 @@ use std::marker::PhantomData;
 
 use super::Pod;
 
-//----------------------------------------------------------------
-
-/// Raw Pointer.
-#[derive(Copy, Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[repr(C)]
-pub struct RawPtr64(u64);
-
-impl From<u64> for RawPtr64 {
-	fn from(address: u64) -> RawPtr64 {
-		RawPtr64(address)
-	}
-}
-impl From<RawPtr64> for u64 {
-	fn from(ptr: RawPtr64) -> u64 {
-		ptr.0
-	}
-}
-
-impl<T: ?Sized> From<TypePtr64<T>> for RawPtr64 {
-	fn from(ptr: TypePtr64<T>) -> RawPtr64 {
-		RawPtr64(ptr.0)
-	}
-}
-
-impl RawPtr64 {
-	/// Returns a raw null pointer.
-	pub fn null() -> RawPtr64 {
-		RawPtr64(0)
-	}
-	/// Returns if the pointer is the null pointer.
-	pub fn is_null(self) -> bool {
-		self.0 == 0
-	}
-	/// Converts to a `u64` value.
-	pub fn into_u64(self) -> u64 {
-		self.0
-	}
-	/// Converts to a typed pointer.
-	pub fn into_typed<T: ?Sized>(self) -> TypePtr64<T> {
-		TypePtr64(self.0, PhantomData)
-	}
-}
-impl ops::Sub for RawPtr64 {
-	type Output = i64;
-	fn sub(self, rhs: RawPtr64) -> i64 {
-		u64::wrapping_sub(self.0, rhs.0) as i64
-	}
-}
-impl fmt::Display for RawPtr64 {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "{:>#018X}", self.0)
-	}
-}
-impl fmt::Debug for RawPtr64 {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "RawPtr64({:>#018X})", self.0)
-	}
-}
-impl ops::Add<u64> for RawPtr64 {
-	type Output = RawPtr64;
-	fn add(self, rhs: u64) -> RawPtr64 {
-		RawPtr64(self.0 + rhs)
-	}
-}
-impl ops::Sub<u64> for RawPtr64 {
-	type Output = RawPtr64;
-	fn sub(self, rhs: u64) -> RawPtr64 {
-		RawPtr64(self.0 - rhs)
-	}
-}
-
-//----------------------------------------------------------------
-
 /// 64bit Typed Pointer.
 #[repr(C)]
-pub struct TypePtr64<T: ?Sized>(u64, PhantomData<fn() -> T>);
+pub struct Ptr64<T: ?Sized>(u64, PhantomData<fn() -> T>);
 
-impl<T: ?Sized> From<u64> for TypePtr64<T> {
-	fn from(addr: u64) -> TypePtr64<T> {
-		TypePtr64(addr, PhantomData)
+impl<T: ?Sized> From<u64> for Ptr64<T> {
+	fn from(addr: u64) -> Ptr64<T> {
+		Ptr64(addr, PhantomData)
 	}
 }
-impl<T: ?Sized> From<TypePtr64<T>> for u64 {
-	fn from(ptr: TypePtr64<T>) -> u64 {
+impl<T: ?Sized> From<Ptr64<T>> for u64 {
+	fn from(ptr: Ptr64<T>) -> u64 {
 		ptr.0
 	}
 }
-impl<T: ?Sized> From<RawPtr64> for TypePtr64<T> {
-	fn from(ptr: RawPtr64) -> TypePtr64<T> {
-		TypePtr64(ptr.0, PhantomData)
-	}
-}
 
-impl<T: ?Sized> TypePtr64<T> {
+impl<T: ?Sized> Ptr64<T> {
 	/// Returns a raw null pointer.
-	pub fn null() -> TypePtr64<T> {
-		TypePtr64(0, PhantomData)
+	pub fn null() -> Ptr64<T> {
+		Ptr64(0, PhantomData)
 	}
 	/// Returns if the pointer is the null pointer.
 	pub fn is_null(self) -> bool {
 		self.0 == 0
 	}
-	/// Converts to a `u64` value.
-	pub fn into_u64(self) -> u64 {
+	/// Converts to a raw integer value.
+	pub fn into_raw(self) -> u64 {
 		self.0
 	}
-	/// Converts to a raw pointer.
-	pub fn into_raw(self) -> RawPtr64 {
-		RawPtr64(self.0)
+}
+impl<T> Ptr64<[T]> {
+	pub fn decay(self) -> Ptr64<T> {
+		Ptr64(self.0, PhantomData)
+	}
+	pub fn at(self, index: usize) -> Ptr64<T> {
+		Ptr64(self.0 + mem::size_of::<T>() as u64 * index as u64, PhantomData)
 	}
 }
-impl<T> TypePtr64<[T]> {
-	pub fn decay(self) -> TypePtr64<T> {
-		TypePtr64(self.0, PhantomData)
-	}
-	pub fn at(self, index: usize) -> TypePtr64<T> {
-		TypePtr64(self.0 + mem::size_of::<T>() as u64 * index as u64, PhantomData)
-	}
-}
-impl<T> ops::Sub for TypePtr64<T> {
+impl<T> ops::Sub for Ptr64<T> {
 	type Output = i64;
-	fn sub(self, rhs: TypePtr64<T>) -> i64 {
+	fn sub(self, rhs: Ptr64<T>) -> i64 {
 		(u64::wrapping_sub(self.0, rhs.0) as i64) / mem::size_of::<T>() as i64
 	}
 }
-impl<T: ?Sized> fmt::Display for TypePtr64<T> {
+impl<T: ?Sized> fmt::Display for Ptr64<T> {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		write!(f, "{:>#018X}", self.0)
 	}
 }
-impl<T: ?Sized> fmt::Debug for TypePtr64<T> {
+impl<T: ?Sized> fmt::Debug for Ptr64<T> {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "TypePtr64({:>#018X})", self.0)
+		write!(f, "Ptr64({:>#018X})", self.0)
 	}
 }
-impl<T> ops::Add<u64> for TypePtr64<T> {
-	type Output = TypePtr64<T>;
-	fn add(self, rhs: u64) -> TypePtr64<T> {
-		TypePtr64(self.0 + rhs * mem::size_of::<T>() as u64, self.1)
+impl<T> ops::Add<u64> for Ptr64<T> {
+	type Output = Ptr64<T>;
+	fn add(self, rhs: u64) -> Ptr64<T> {
+		Ptr64(self.0 + rhs * mem::size_of::<T>() as u64, self.1)
 	}
 }
-impl<T> ops::Sub<u64> for TypePtr64<T> {
-	type Output = TypePtr64<T>;
-	fn sub(self, rhs: u64) -> TypePtr64<T> {
-		TypePtr64(self.0 - rhs * mem::size_of::<T>() as u64, self.1)
+impl<T> ops::Sub<u64> for Ptr64<T> {
+	type Output = Ptr64<T>;
+	fn sub(self, rhs: u64) -> Ptr64<T> {
+		Ptr64(self.0 - rhs * mem::size_of::<T>() as u64, self.1)
 	}
 }
-impl<T: ?Sized> Clone for TypePtr64<T> {
+impl<T: ?Sized> Clone for Ptr64<T> {
 	fn clone(&self) -> Self {
-		TypePtr64(self.0, self.1)
+		Ptr64(self.0, self.1)
 	}
 }
-impl<T: ?Sized> Default for TypePtr64<T> {
-	fn default() -> TypePtr64<T> {
-		TypePtr64::null()
+impl<T: ?Sized> Default for Ptr64<T> {
+	fn default() -> Ptr64<T> {
+		Ptr64::null()
 	}
 }
-impl<T: ?Sized> PartialEq for TypePtr64<T> {
+impl<T: ?Sized> PartialEq for Ptr64<T> {
 	fn eq(&self, rhs: &Self) -> bool {
 		self.0 == rhs.0
 	}
 }
-impl<T: ?Sized> PartialOrd for TypePtr64<T> {
-	fn partial_cmp(&self, rhs: &TypePtr64<T>) -> Option<cmp::Ordering> {
+impl<T: ?Sized> PartialOrd for Ptr64<T> {
+	fn partial_cmp(&self, rhs: &Ptr64<T>) -> Option<cmp::Ordering> {
 		self.0.partial_cmp(&rhs.0)
 	}
 }
-impl<T: ?Sized> Copy for TypePtr64<T> {}
-impl<T: ?Sized> Eq for TypePtr64<T> {}
-impl<T: ?Sized> Ord for TypePtr64<T> {
-	fn cmp(&self, rhs: &TypePtr64<T>) -> cmp::Ordering {
+impl<T: ?Sized> Copy for Ptr64<T> {}
+impl<T: ?Sized> Eq for Ptr64<T> {}
+impl<T: ?Sized> Ord for Ptr64<T> {
+	fn cmp(&self, rhs: &Ptr64<T>) -> cmp::Ordering {
 		self.0.cmp(&rhs.0)
 	}
 }
 
-unsafe impl Pod for RawPtr64 {}
-unsafe impl<T: ?Sized> Pod for TypePtr64<T> {}
+unsafe impl<T: ?Sized> Pod for Ptr64<T> {}
 
 //----------------------------------------------------------------
 
@@ -190,26 +107,14 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn rawptr64() {
-		let a = RawPtr64::from(0x1000);
-		let b = a + 0x20;
-		let c = a - 0x20;
-		assert_eq!(mem::size_of_val(&a), 8);
-		assert_eq!(b - a, 0x20);
-		assert_eq!(c.into_u64(), 0x0FE0);
-		assert_eq!(format!("{}", a), "0x0000000000001000");
-		assert_eq!(c.into_typed::<i64>(), TypePtr64::<i64>::from(0x1020));
-	}
-
-	#[test]
 	fn typeptr64() {
-		let a = TypePtr64::<f64>::from(0x2000);
+		let a = Ptr64::<f64>::from(0x2000);
 		let b = a + 0x40;
 		let c = a - 0x40;
 		assert_eq!(mem::size_of_val(&a), 8);
 		assert_eq!(c - a, -0x40);
-		assert_eq!(b.into_u64(), 0x2200);
+		assert_eq!(b.into_raw(), 0x2200);
 		assert_eq!(format!("{}", a), "0x0000000000002000");
-		assert_eq!(c.into_raw(), RawPtr64::from(0x1E00));
+		assert_eq!(c.into_raw(), 0x1E00);
 	}
 }

--- a/src/windows/system/system_modules.rs
+++ b/src/windows/system/system_modules.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 
 use ntdll::*;
 
-use crate::ptr::{RawPtr, NativePtr};
 use crate::{AsInner, util};
 
 //----------------------------------------------------------------
@@ -80,8 +79,8 @@ impl fmt::Debug for SystemModules {
 pub struct SystemModule(RTL_PROCESS_MODULE_INFORMATION);
 impl_inner!(SystemModule: RTL_PROCESS_MODULE_INFORMATION);
 impl SystemModule {
-	pub fn image_base(&self) -> RawPtr {
-		RawPtr::from_usize(self.0.ImageBase as usize)
+	pub fn image_base(&self) -> usize {
+		self.0.ImageBase as usize
 	}
 	pub fn image_size(&self) -> usize {
 		self.0.ImageSize as usize
@@ -105,8 +104,8 @@ impl SystemModule {
 impl fmt::Debug for SystemModule {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.debug_struct("SystemModule")
-			.field("image_base", &self.image_base())
-			.field("image_size", &self.image_size())
+			.field("image_base", &format_args!("{:#x}", self.image_base()))
+			.field("image_size", &format_args!("{:#x}", self.image_size()))
 			.field("flags", &self.flags())
 			.field("file_name", &self.file_name())
 			.field("full_path_name", &self.full_path_name())


### PR DESCRIPTION
Drop RawPtrXX types and just use naked uXX types instead.
In place, rename TypePtrXX to just PtrXX.
Cast to usize as needed for windows APIs, otherwise stick with uXX.